### PR TITLE
Git Integration: git commit w/ jovian commit, log commit info

### DIFF
--- a/jovian/__init__.py
+++ b/jovian/__init__.py
@@ -128,7 +128,7 @@ def commit(secret=False, nb_filename=None, files=[], capture_env=True,
         if is_git():
             reset(which=['dataset'])  # resets git commit info
 
-            git_commit(message)
+            git_commit(commit_msg)
             log('Git commit Done.')
 
             git_info = {

--- a/jovian/__init__.py
+++ b/jovian/__init__.py
@@ -126,7 +126,7 @@ def commit(secret=False, nb_filename=None, files=[], capture_env=True,
     # Commit to git and log commit hash
     if git:
         if is_git():
-            reset(which=['dataset'])  # resets git commit info
+            reset(which=['git'])  # resets git commit info
 
             git_commit(commit_msg)
             log('Git commit Done.')

--- a/jovian/__init__.py
+++ b/jovian/__init__.py
@@ -10,6 +10,7 @@ from jovian.utils.configure import configure
 from jovian.utils.configure import reset as reset_config
 from jovian.utils.constants import FILENAME_MSG, RC_FILENAME
 from jovian.utils.credentials import read_webapp_url
+from jovian.utils.git import git_commit, git_current_commit, git_remote, git_rel_path, is_git
 from jovian.utils.jupyter import get_notebook_name, in_notebook, save_notebook, set_notebook_name
 from jovian.utils.logger import log
 from jovian.utils.misc import get_flavor
@@ -25,23 +26,30 @@ _current_slug = None
 _data_blocks = []
 
 
-def reset():
-    """Reset the tracked hyperparameters & metrics (for a fresh experiment)
+def reset(which=[]):
+    """Reset the tracked hyperparameters, metrics or dataset (for a fresh experiment)
+
+    Args:
+        which(list, optional): By default resets all type of records. For specific filter
+                            add keywords `metrics`, `hyperparams`, `dataset` individually
+                            or in combinations to reset those type of records.  
     Example
         .. code-block::
 
             import jovian
 
-            jovian.reset()
+            jovian.reset(which=['hyperparams`, `metrics`])
     """
     global _current_slug
     global _data_blocks
+
     _current_slug = None
-    _data_blocks = []
+    # creates a filtered list of record types not in which list
+    _data_blocks = [(i, j) for (i, j) in _data_blocks if j not in which]
 
 
 def commit(secret=False, nb_filename=None, files=[], capture_env=True,
-           env_type='conda', notebook_id=None, create_new=None, artifacts=[]):
+           env_type='conda', notebook_id=None, create_new=None, artifacts=[], git=False, commit_msg="jovian commit"):
     """Commits a Jupyter Notebook with its environment to Jovian.
 
     Saves the checkpoint of the notebook, captures the required dependencies from 
@@ -79,6 +87,11 @@ def commit(secret=False, nb_filename=None, files=[], capture_env=True,
         artifacts(array, optional): Any outputs files or artifacts generated from the modeling processing.
             This can include model weights/checkpoints, generated CSVs, images etc.
 
+        git(bool, optional): Whether to perform git commit along with jovian commit.Defaults to False.
+
+        commit_msg("jovian commit", optional): Has a default string message as `jovian commit`, pass a
+            string for custom commit messages.
+
     .. attention::
         Pass notebook's name to nb_filename argument, in certain environments like Jupyter Lab and password protected notebooks sometimes it may fail to detect notebook automatically.
     .. _Jovian: https://jovian.ml
@@ -109,6 +122,25 @@ def commit(secret=False, nb_filename=None, files=[], capture_env=True,
     if nb_filename is None:
         log(FILENAME_MSG)
         return
+
+    # Commit to git and log commit hash
+    if git:
+        if is_git():
+            reset(which=['dataset'])  # resets git commit info
+
+            git_commit(message)
+            log('Git commit Done.')
+
+            git_info = {
+                'remoteRepository': git_remote(),
+                'commitHash': git_current_commit(),
+                'nbFilename': nb_filename,
+                'relativePath': git_rel_path()
+            }
+            log_git(git_info, verbose=False)
+
+        else:
+            log('Failed to detect a git repo. Please check the diretory you are committing from.')
 
     # Check whether to create a new gist, or update an old one
     if not create_new and notebook_id is None:
@@ -204,8 +236,12 @@ def commit(secret=False, nb_filename=None, files=[], capture_env=True,
 
     # Record metrics & hyperparameters
     if len(_data_blocks) > 0:
-        log('Recording metrics & hyperparameters..')
-        commit_records(slug, _data_blocks, version)
+
+        # unpack only the trackingSlugs
+        _data_blocks_trackingSlugs = [i for i, _ in _data_blocks]
+
+        log('Recording metrics/hyperparameters/dataset/git_commit_information')
+        commit_records(slug, _data_blocks_trackingSlugs, version)
 
     # Print commit URL
     log('Committed successfully! ' + read_webapp_url() +
@@ -232,8 +268,10 @@ def log_hyperparams(data, verbose=True):
             jovian.log_hyperparams(hyperparams)
     """
     global _data_blocks
-    res = post_block(data, 'hyperparams')
-    _data_blocks.append(res['tracking']['trackingSlug'])
+    recordType = 'hyperparams'
+
+    res = post_block(data, recordType)
+    _data_blocks.append((res['tracking']['trackingSlug'], recordType))
     if verbose:
         log('Hyperparameters logged.')
 
@@ -260,8 +298,11 @@ def log_metrics(data, verbose=True):
             jovian.log_metrics(metrics)
     """
     global _data_blocks
-    res = post_block(data, 'metrics')
-    _data_blocks.append(res['tracking']['trackingSlug'])
+    recordType = 'metrics'
+
+    res = post_block(data, recordType)
+    _data_blocks.append((res['tracking']['trackingSlug'], recordType))
+
     if verbose:
         log('Metrics logged.')
 
@@ -286,10 +327,31 @@ def log_dataset(data, verbose=True):
             jovian.log_dataset(data)
     """
     global _data_blocks
-    res = post_block(data, 'dataset')
-    _data_blocks.append(res['tracking']['trackingSlug'])
+    recordType = 'dataset'
+
+    res = post_block(data, recordType)
+    _data_blocks.append((res['tracking']['trackingSlug'], recordType))
+
     if verbose:
         log('Dataset logged.')
+
+
+def log_git(data, verbose=True):
+    """Record the git information.
+
+    Args:
+        data(dict): A python dict or a array of dicts to be recorded as Dataset.
+
+        verbose(bool, optional): By default it prints the acknowledgement, you can remove this by setting the argument to False.
+    """
+    global _data_blocks
+    recordType = 'git'
+
+    res = post_block(data, recordType)
+    _data_blocks.append((res['tracking']['trackingSlug'], recordType))
+
+    if verbose:
+        log('Git logged.')Recording metrics & hyperparameters..
 
 
 def notify(data, verbose=True, safe=False):

--- a/jovian/__init__.py
+++ b/jovian/__init__.py
@@ -272,6 +272,7 @@ def log_hyperparams(data, verbose=True):
 
     res = post_block(data, recordType)
     _data_blocks.append((res['tracking']['trackingSlug'], recordType))
+
     if verbose:
         log('Hyperparameters logged.')
 
@@ -351,7 +352,7 @@ def log_git(data, verbose=True):
     _data_blocks.append((res['tracking']['trackingSlug'], recordType))
 
     if verbose:
-        log('Git logged.')Recording metrics & hyperparameters..
+        log('Git logged.')
 
 
 def notify(data, verbose=True, safe=False):

--- a/jovian/__init__.py
+++ b/jovian/__init__.py
@@ -48,8 +48,16 @@ def reset(which=[]):
     _data_blocks = [(i, j) for (i, j) in _data_blocks if j not in which]
 
 
-def commit(secret=False, nb_filename=None, files=[], capture_env=True,
-           env_type='conda', notebook_id=None, create_new=None, artifacts=[], git=False, commit_msg="jovian commit"):
+def commit(secret=False,
+           nb_filename=None,
+           files=[],
+           capture_env=True,
+           env_type='conda',
+           notebook_id=None,
+           create_new=None,
+           artifacts=[],
+           do_git_commit=True,
+           git_commit_msg="jovian commit"):
     """Commits a Jupyter Notebook with its environment to Jovian.
 
     Saves the checkpoint of the notebook, captures the required dependencies from 
@@ -124,11 +132,11 @@ def commit(secret=False, nb_filename=None, files=[], capture_env=True,
         return
 
     # Commit to git and log commit hash
-    if git:
+    if do_git_commit:
         if is_git():
             reset(which=['git'])  # resets git commit info
 
-            git_commit(commit_msg)
+            git_commit(git_commit_msg)
             log('Git commit Done.')
 
             git_info = {
@@ -338,10 +346,10 @@ def log_dataset(data, verbose=True):
 
 
 def log_git(data, verbose=True):
-    """Record the git information.
+    """Record the git-related information.
 
     Args:
-        data(dict): A python dict or a array of dicts to be recorded as Dataset.
+        data(dict): A python dict or a array of dicts to be recorded as a git related block.
 
         verbose(bool, optional): By default it prints the acknowledgement, you can remove this by setting the argument to False.
     """

--- a/jovian/utils/git.py
+++ b/jovian/utils/git.py
@@ -1,0 +1,49 @@
+"""Git related utilities"""
+import os
+from subprocess import call
+
+
+def is_git():
+    """Check whether we are in a git repository"""
+    return call(['git', 'rev-parse']) == 0
+
+
+def git_branch():
+    return os.popen('git branch | grep \* | cut -d \' \' -f2').read().strip()
+
+
+def git_remote():
+    """Get the remote URL"""
+    return os.popen('git config --get remote.origin.url').read().replace(".git\n", "").strip()
+
+
+def git_current_commit():
+    """Get the current commit"""
+    return os.popen('git rev-parse HEAD').read().strip()
+
+
+def git_root():
+    """Get the root of the git repository"""
+    return os.popen('git rev-parse --show-toplevel').read().strip()
+
+
+def git_commit(message):
+    """Create a new commit"""
+    return os.system('cd ' + git_root() + ' && git add . &&  git commit -a -m "' + message + '" && cd -')
+
+
+def git_push():
+    """Push the branch to origin"""
+    return os.system("git push origin " + git_branch())
+
+
+def git_commit_push(message):
+    """Create a commit and push to origin"""
+    if is_git():
+        git_commit(message)
+        git_push()
+        return {
+            'remote': git_remote(),
+            'branch': git_branch(),
+            'commit': git_commit(message)
+        }

--- a/jovian/utils/git.py
+++ b/jovian/utils/git.py
@@ -47,3 +47,10 @@ def git_commit_push(message):
             'branch': git_branch(),
             'commit': git_commit(message)
         }
+
+
+def git_rel_path():
+    """Returns relative path from the git root directory."""
+    root_dir = git_root()
+    file_dir = os.path.abspath('')
+    return os.path.relpath(file_dir, root_dir)


### PR DESCRIPTION
Flow:
- [x] Detect whether we are committing from a git repository
- [x] Commit the notebook file
- [x] Capture the commit hash, remote URL etc.
- [x] Create a record of type 'git' which can be used in the frontend to link to the Git repo

**PP**

- [x] Reset the `git records` for every new commit. As it retains the old record if the notebook is not restarted without affecting hyp, metrics
    - [x] Made a general way to selectively reset different record types

~- [ ] Case: git commit won't happen when there is no change.
    *  Should display the mes4ab48ddc437866afc81c6d2d32959403cede968esage about this and perform jovian commit
    * **OR** terminate jovian commit if this is the case~


