### PR TITLE
improve clone messaging

### DIFF
--- a/jovian/utils/clone.py
+++ b/jovian/utils/clone.py
@@ -56,7 +56,7 @@ def get_gist(slug, version, fresh):
 
 def post_clone_msg(title):
     import click
-    log("Cloned successfully to '{}'".format(title), color='bright_green')
+    log("Cloned successfully to '{}'".format(title), color='green')
     click.echo(click.style('\nNext steps:', fg='yellow', underline=True) +
                click.style("""
   $ cd {}                     

--- a/jovian/utils/clone.py
+++ b/jovian/utils/clone.py
@@ -56,14 +56,13 @@ def get_gist(slug, version, fresh):
 
 def post_clone_msg(title):
     import click
-    log("Cloned successfully to '{}'".format(title), color='bright_green') 
-    click.echo(click.style('\nNext steps:', fg='yellow', underline=True) + \
+    log("Cloned successfully to '{}'".format(title), color='bright_green')
+    click.echo(click.style('\nNext steps:', fg='yellow', underline=True) +
                click.style("""
   $ cd {}                     
   $ jovian install            
   $ conda activate <env_name> 
   $ jupyter notebook""".format(title), bold=True))
-    
 
     print("""
 Replace <env_name> with the name of your environment (without the '<' & '>')

--- a/jovian/utils/clone.py
+++ b/jovian/utils/clone.py
@@ -56,21 +56,21 @@ def get_gist(slug, version, fresh):
 def post_clone_msg(title):
     import click
     log("Cloned successfully to '{}'".format(title), color='green')
-    click.echo(click.style('\nNext steps:', fg='yellow', underline=True) +
-               click.style("""
+    log(click.style('\nNext steps:', fg='yellow', underline=True) +
+        click.style("""
   $ cd {}                     
   $ jovian install            
   $ conda activate <env_name> 
-  $ jupyter notebook""".format(title), bold=True))
+  $ jupyter notebook""".format(title), bold=True), pre=False)
 
-    print("""
+    log("""
 Replace <env_name> with the name of your environment (without the '<' & '>')
 Jovian uses Anaconda ( https://conda.io/ ) under the hood, 
 so please make sure you have it installed and added to path. 
 * If you face issues with `jovian install`, try `conda env update`.
 * If you face issues with `conda activate`, try `source activate <env_name>` 
   or `activate <env_name>` to activate the virtual environment.
-""")
+""", pre=False)
 
 
 def clone(slug, version=None, fresh=True):

--- a/jovian/utils/clone.py
+++ b/jovian/utils/clone.py
@@ -72,7 +72,7 @@ so please make sure you have it installed and added to path.
 * If you face issues with `jovian install`, try `conda env update`.
 * If you face issues with `conda activate`, try `source activate <env_name>` 
   or `activate <env_name>` to activate the virtual environment.
-""".format(title, title))
+""")
 
 
 def clone(slug, version=None, fresh=True):

--- a/jovian/utils/clone.py
+++ b/jovian/utils/clone.py
@@ -47,7 +47,6 @@ def get_gist(slug, version, fresh):
         url = _u('user/' + username + '/gist/' + title + _v(version))
     else:
         url = _u('gist/' + slug + _v(version))
-    # print(url)
     res = get(url, headers=_h(fresh))
     if res.status_code == 200:
         return res.json()['data']

--- a/jovian/utils/clone.py
+++ b/jovian/utils/clone.py
@@ -47,7 +47,7 @@ def get_gist(slug, version, fresh):
         url = _u('user/' + username + '/gist/' + title + _v(version))
     else:
         url = _u('gist/' + slug + _v(version))
-    print(url)
+    # print(url)
     res = get(url, headers=_h(fresh))
     if res.status_code == 200:
         return res.json()['data']
@@ -55,23 +55,24 @@ def get_gist(slug, version, fresh):
 
 
 def post_clone_msg(title):
-    return """Cloned successfully to '{}'. 
+    import click
+    log("Cloned successfully to '{}'".format(title), color='bright_green') 
+    click.echo(click.style('\nNext steps:', fg='yellow', underline=True) + \
+               click.style("""
+  $ cd {}                     
+  $ jovian install            
+  $ conda activate <env_name> 
+  $ jupyter notebook""".format(title), bold=True))
+    
 
-Next steps:
-$ cd {}   # Enter the directory
-$ jovian install     # Install dependencies
-$ conda activate <env_name> # Activate environment
-$ jupyter notebook   # Start Jupyter
-
+    print("""
 Replace <env_name> with the name of your environment (without the '<' & '>')
 Jovian uses Anaconda ( https://conda.io/ ) under the hood, 
 so please make sure you have it installed and added to path. 
 * If you face issues with `jovian install`, try `conda env update`.
 * If you face issues with `conda activate`, try `source activate <env_name>` 
   or `activate <env_name>` to activate the virtual environment.
-
-{}
-""".format(title, title, ISSUES_MSG)
+""".format(title, title))
 
 
 def clone(slug, version=None, fresh=True):
@@ -108,7 +109,7 @@ def clone(slug, version=None, fresh=True):
 
     # Print success message and instructions
     if fresh:
-        log(post_clone_msg(title))
+        post_clone_msg(title)
     else:
         log('Files dowloaded successfully in current directory')
 

--- a/jovian/utils/constants.py
+++ b/jovian/utils/constants.py
@@ -6,7 +6,7 @@ RC_FILENAME = ".jovianrc"
 FILENAME_MSG = 'Failed to detect notebook filename. Please provide the notebook filename ' + \
     '(including .ipynb extension) as the "nb_filename" argument to "jovian.commit".'
 ISSUES_MSG = """NOTE: Jovian is currently in beta, so if you face any issues, 
-      please report them here: https://github.com/JovianML/jovian-py/issues"""
+               please report them here: https://github.com/JovianML/jovian-py/issues"""
 
 LINUX = 'linux'
 WINDOWS = 'windows'

--- a/jovian/utils/logger.py
+++ b/jovian/utils/logger.py
@@ -3,10 +3,9 @@ from sys import stderr
 import click
 
 
-def log(msg, error=False, color=None):
+def log(msg, pre=True, error=False, color=None):
     """Print a message to stdout"""
     if error:
-        click.secho('[jovian] Error: ' + msg, err=True, fg='bright_red')
+        click.secho(('[jovian] ' if pre else '') + 'Error: ' + msg, err=True, fg='bright_red')
     else:
-        click.secho('[jovian] ', bold=True, nl=False)
-        click.secho(msg, fg=color)
+        click.echo(('[jovian] ' if pre else '') + click.style(msg, fg=color))

--- a/jovian/utils/logger.py
+++ b/jovian/utils/logger.py
@@ -8,5 +8,5 @@ def log(msg, error=False, color=None):
     if error:
         click.secho('[jovian] Error: ' + msg, err=True, fg='bright_red')
     else:
-        click.secho('[jovian] ', fg='blue', bold=True, nl=False)
+        click.secho('[jovian] ', bold=True, nl=False)
         click.secho(msg, fg=color)

--- a/jovian/utils/logger.py
+++ b/jovian/utils/logger.py
@@ -1,10 +1,12 @@
 from __future__ import print_function
 from sys import stderr
+import click
 
 
-def log(msg, error=False):
+def log(msg, error=False, color=None):
     """Print a message to stdout"""
     if error:
-        print('[jovian] Error: ' + msg, file=stderr)
+        click.secho('[jovian] Error: ' + msg, err=True, fg='bright_red')
     else:
-        print('[jovian] ' + msg)
+        click.secho('[jovian] ', fg='blue', bold=True, nl=False)
+        click.secho(msg, fg=color)


### PR DESCRIPTION
Changes: 
1. Removed printing of URL
2. Added red colour for error messages

## Terminal
### On dark theme:
![Screenshot 2019-12-18 at 1 59 56 PM](https://user-images.githubusercontent.com/39169550/71069449-c57bdd80-219e-11ea-9a1e-b6596bb0abcd.png)

### On light theme:
![Screenshot 2019-12-18 at 2 01 10 PM](https://user-images.githubusercontent.com/39169550/71069495-ddebf800-219e-11ea-96d7-ade357d970d2.png)


### Error message in terminal (from script)
![Screenshot 2019-12-18 at 2 02 18 PM](https://user-images.githubusercontent.com/39169550/71069579-0b38a600-219f-11ea-8299-6a45dc74a2b9.png)

![Screenshot 2019-12-18 at 2 02 54 PM](https://user-images.githubusercontent.com/39169550/71069614-1c81b280-219f-11ea-9584-8dcd3bec1690.png)



## Jupyter Notebook
### clone messaging
![Screenshot 2019-12-18 at 2 05 24 PM](https://user-images.githubusercontent.com/39169550/71069807-7b472c00-219f-11ea-95dd-79a0e6cd704e.png)

### Error message in Jupyter Notebook
![Screenshot 2019-12-06 at 3 49 03 PM](https://user-images.githubusercontent.com/39169550/70315753-4a323780-1840-11ea-84dd-f1e302972f2f.png)


[ch1241]
