### PR TITLE
Improve logging API with kwargs

### DIFF
--- a/jovian/__init__.py
+++ b/jovian/__init__.py
@@ -1,7 +1,7 @@
 
 from jovian._version import __version__
 from jovian.utils.commit import commit
-from jovian.utils.records import log_hyperparams, log_metrics, log_dataset, log_git, reset_records
+from jovian.utils.records import log_hyperparams, log_metrics, log_dataset, log_git, reset
 from jovian.utils.slack import notify
 from jovian.utils.configure import reset_config, configure
 from jovian.utils.initialize import _initialize_jovian

--- a/jovian/__init__.py
+++ b/jovian/__init__.py
@@ -1,7 +1,8 @@
 
 from jovian._version import __version__
 from jovian.utils.commit import commit
-from jovian.utils.records import log_hyperparams, log_metrics, log_dataset, log_git, reset
+from jovian.utils.records import (log_hyperparams, log_metrics, log_dataset,
+                                  log_git, reset, get_records)
 from jovian.utils.slack import notify
 from jovian.utils.configure import reset_config, configure
 from jovian.utils.initialize import _initialize_jovian

--- a/jovian/callbacks/fastai.py
+++ b/jovian/callbacks/fastai.py
@@ -2,7 +2,7 @@ from torch import Tensor
 from fastai.basic_train import Learner
 from fastai.callback import Callback
 
-from jovian.utils.records import log_hyperparams, log_metrics, reset_records
+from jovian.utils.records import log_hyperparams, log_metrics, reset
 from jovian.utils.logger import log
 
 
@@ -41,7 +41,7 @@ class JovianFastaiCallback(Callback):
 
     def on_train_begin(self, n_epochs: int, metrics_names: list, **ka):
         if self.reset_tracking:
-            reset_records('hyperparams', 'metrics')
+            reset('hyperparams', 'metrics')
         hyp_dict = {
             'epochs': n_epochs,
             'batch_size': self.learn.data.batch_size,

--- a/jovian/callbacks/keras.py
+++ b/jovian/callbacks/keras.py
@@ -2,7 +2,7 @@ from keras.backend import get_value
 from keras.callbacks import Callback
 import json
 
-from jovian.utils.records import log_metrics, log_hyperparams, reset_records
+from jovian.utils.records import log_metrics, log_hyperparams, reset
 from jovian.utils.slack import notify
 
 
@@ -41,7 +41,7 @@ class JovianKerasCallback(Callback):
     def on_train_begin(self, logs=None):
         # Reset state if required
         if self.reset_tracking:
-            reset_records('hyperparams', 'metrics')
+            reset('hyperparams', 'metrics')
 
         hyp_dict = {
             'epochs': self.params['epochs'],

--- a/jovian/tests/utils/test_records.py
+++ b/jovian/tests/utils/test_records.py
@@ -1,53 +1,53 @@
 from unittest import TestCase, mock
-from jovian.utils.records import get_record_slugs, reset_records, log_hyperparams, log_metrics, log_dataset, log_git
+from jovian.utils.records import get_records, reset, log_hyperparams, log_metrics, log_dataset, log_git
 import jovian.utils.records
 _d = jovian.utils.records._data_blocks
 
 
 class FakeRecords(TestCase):
     def setUp(self):
-        jovian.utils.records._data_blocks = [('fake_slug_metrics_1', 'metrics'),
-                                             ('fake_slug_metrics_2', 'metrics'),
-                                             ('fake_slug_hyperparams_1', 'hyperparams'),
-                                             ('fake_slug_hyperparams_2', 'hyperparams')]
+        jovian.utils.records._data_blocks = [('fake_slug_metrics_1', 'metrics', {}),
+                                             ('fake_slug_metrics_2', 'metrics', {}),
+                                             ('fake_slug_hyperparams_1', 'hyperparams', {}),
+                                             ('fake_slug_hyperparams_2', 'hyperparams', {})]
 
     def tearDown(self):
         jovian.utils.records._data_blocks = _d
 
 
-class TestGetRecordSlugs(FakeRecords):
-    def test_get_record_slugs_without_type(self):
+class TestGetRecords(FakeRecords):
+    def test_get_records_without_type(self):
         expected_result = ['fake_slug_metrics_1',
                            'fake_slug_metrics_2',
                            'fake_slug_hyperparams_1',
                            'fake_slug_hyperparams_2']
 
-        self.assertEqual(get_record_slugs(), expected_result)
+        self.assertEqual(get_records(), expected_result)
 
-    def test_get_record_slugs_with_type(self):
-        expected_result = [('fake_slug_metrics_1', 'metrics'),
-                           ('fake_slug_metrics_2', 'metrics'),
-                           ('fake_slug_hyperparams_1', 'hyperparams'),
-                           ('fake_slug_hyperparams_2', 'hyperparams')]
-        self.assertEqual(get_record_slugs(with_type=True), expected_result)
+    def test_get_records_with_type(self):
+        expected_result = [('fake_slug_metrics_1', 'metrics', {}),
+                           ('fake_slug_metrics_2', 'metrics', {}),
+                           ('fake_slug_hyperparams_1', 'hyperparams', {}),
+                           ('fake_slug_hyperparams_2', 'hyperparams', {})]
+        self.assertEqual(get_records(slug_only=False), expected_result)
 
 
-class TestResetRecords(FakeRecords):
-    def test_reset_records(self):
-        reset_records()
+class TestReset(FakeRecords):
+    def test_reset(self):
+        reset()
         expected_result = []
         self.assertEqual(jovian.utils.records._data_blocks, expected_result)
 
-    def test_reset_records_metrics(self):
-        reset_records('metrics')
-        expected_result = [('fake_slug_hyperparams_1', 'hyperparams'),
-                           ('fake_slug_hyperparams_2', 'hyperparams')]
+    def test_reset_metrics(self):
+        reset('metrics')
+        expected_result = [('fake_slug_hyperparams_1', 'hyperparams', {}),
+                           ('fake_slug_hyperparams_2', 'hyperparams', {})]
         self.assertEqual(jovian.utils.records._data_blocks, expected_result)
 
-    def test_reset_records_hyperparams(self):
-        reset_records('hyperparams')
-        expected_result = [('fake_slug_metrics_1', 'metrics'),
-                           ('fake_slug_metrics_2', 'metrics')]
+    def test_reset_hyperparams(self):
+        reset('hyperparams')
+        expected_result = [('fake_slug_metrics_1', 'metrics', {}),
+                           ('fake_slug_metrics_2', 'metrics', {})]
         self.assertEqual(jovian.utils.records._data_blocks, expected_result)
 
 
@@ -73,11 +73,11 @@ class TestLogHyperparams(FakeRecords):
             'arch_name': 'cnn_1',
             'lr': .001
         }
-        expected_result = [('fake_slug_metrics_1', 'metrics'),
-                           ('fake_slug_metrics_2', 'metrics'),
-                           ('fake_slug_hyperparams_1', 'hyperparams'),
-                           ('fake_slug_hyperparams_2', 'hyperparams'),
-                           ('fake_slug_3', 'hyperparams')]
+        expected_result = [('fake_slug_metrics_1', 'metrics', {}),
+                           ('fake_slug_metrics_2', 'metrics', {}),
+                           ('fake_slug_hyperparams_1', 'hyperparams', {}),
+                           ('fake_slug_hyperparams_2', 'hyperparams', {}),
+                           ('fake_slug_3', 'hyperparams', data)]
 
         log_hyperparams(data)
         self.assertEqual(jovian.utils.records._data_blocks, expected_result)
@@ -91,11 +91,11 @@ class TestLogMetrics(FakeRecords):
             'acc': 0.89,
             'val_acc': 0.86
         }
-        expected_result = [('fake_slug_metrics_1', 'metrics'),
-                           ('fake_slug_metrics_2', 'metrics'),
-                           ('fake_slug_hyperparams_1', 'hyperparams'),
-                           ('fake_slug_hyperparams_2', 'hyperparams'),
-                           ('fake_slug_3', 'metrics')]
+        expected_result = [('fake_slug_metrics_1', 'metrics', {}),
+                           ('fake_slug_metrics_2', 'metrics', {}),
+                           ('fake_slug_hyperparams_1', 'hyperparams', {}),
+                           ('fake_slug_hyperparams_2', 'hyperparams', {}),
+                           ('fake_slug_3', 'metrics', data)]
 
         log_metrics(data)
         self.assertEqual(jovian.utils.records._data_blocks, expected_result)
@@ -104,16 +104,16 @@ class TestLogMetrics(FakeRecords):
 class TestLogDataset(FakeRecords):
 
     @mock.patch("jovian.utils.records.api.post_block", side_effect=mock_api_post_block)
-    def test_log_metrics(self, mock_api_post_block):
+    def test_log_dataset(self, mock_api_post_block):
         data = {
             'col1': [1, 2, 3],
             'col2': [4, 5, 6]
         }
-        expected_result = [('fake_slug_metrics_1', 'metrics'),
-                           ('fake_slug_metrics_2', 'metrics'),
-                           ('fake_slug_hyperparams_1', 'hyperparams'),
-                           ('fake_slug_hyperparams_2', 'hyperparams'),
-                           ('fake_slug_3', 'dataset')]
+        expected_result = [('fake_slug_metrics_1', 'metrics', {}),
+                           ('fake_slug_metrics_2', 'metrics', {}),
+                           ('fake_slug_hyperparams_1', 'hyperparams', {}),
+                           ('fake_slug_hyperparams_2', 'hyperparams', {}),
+                           ('fake_slug_3', 'dataset', data)]
 
         log_dataset(data)
         self.assertEqual(jovian.utils.records._data_blocks, expected_result)
@@ -122,18 +122,18 @@ class TestLogDataset(FakeRecords):
 class TestLogGit(FakeRecords):
 
     @mock.patch("jovian.utils.records.api.post_block", side_effect=mock_api_post_block)
-    def test_log_metrics(self, mock_api_post_block):
+    def test_log_git(self, mock_api_post_block):
         data = {
             'branch': 'sample_branch',
             'commit': 'sample_commit_hash',
             'remote': 'https://github.com/rohitsanj/fakerepo'
         }
 
-        expected_result = [('fake_slug_metrics_1', 'metrics'),
-                           ('fake_slug_metrics_2', 'metrics'),
-                           ('fake_slug_hyperparams_1', 'hyperparams'),
-                           ('fake_slug_hyperparams_2', 'hyperparams'),
-                           ('fake_slug_3', 'git')]
+        expected_result = [('fake_slug_metrics_1', 'metrics', {}),
+                           ('fake_slug_metrics_2', 'metrics', {}),
+                           ('fake_slug_hyperparams_1', 'hyperparams', {}),
+                           ('fake_slug_hyperparams_2', 'hyperparams', {}),
+                           ('fake_slug_3', 'git', data)]
 
         log_git(data)
         self.assertEqual(jovian.utils.records._data_blocks, expected_result)
@@ -150,7 +150,7 @@ def test_log_hyperparams_verbose(mock_api_post_block, capsys):
     log_hyperparams(data)
     captured = capsys.readouterr()
 
-    expected_result = '[jovian] Hyperparameters logged.'
+    expected_result = '[jovian] Hyperparams logged.'
     assert expected_result == captured.out.strip()
 
 
@@ -190,5 +190,5 @@ def test_log_git_verbose(mock_api_post_block, capsys):
     log_git(data)
     captured = capsys.readouterr()
 
-    expected_result = '[jovian] Git information logged.'
+    expected_result = '[jovian] Git logged.'
     assert expected_result == captured.out.strip()

--- a/jovian/tests/utils/test_records.py
+++ b/jovian/tests/utils/test_records.py
@@ -22,14 +22,14 @@ class TestGetRecords(FakeRecords):
                            'fake_slug_hyperparams_1',
                            'fake_slug_hyperparams_2']
 
-        self.assertEqual(get_records(), expected_result)
+        self.assertEqual(get_records(slug_only=True), expected_result)
 
     def test_get_records_with_type(self):
         expected_result = [('fake_slug_metrics_1', 'metrics', {}),
                            ('fake_slug_metrics_2', 'metrics', {}),
                            ('fake_slug_hyperparams_1', 'hyperparams', {}),
                            ('fake_slug_hyperparams_2', 'hyperparams', {})]
-        self.assertEqual(get_records(slug_only=False), expected_result)
+        self.assertEqual(get_records(), expected_result)
 
 
 class TestReset(FakeRecords):
@@ -87,7 +87,7 @@ class TestLogMetrics(FakeRecords):
 
     @mock.patch("jovian.utils.records.api.post_block", side_effect=mock_api_post_block)
     def test_log_metrics(self, mock_api_post_block):
-        data = { 'acc': 0.89, 'val_acc': 0.86}
+        data = {'acc': 0.89, 'val_acc': 0.86}
         expected_result = [('fake_slug_metrics_1', 'metrics', {}),
                            ('fake_slug_metrics_2', 'metrics', {}),
                            ('fake_slug_hyperparams_1', 'hyperparams', {}),

--- a/jovian/tests/utils/test_records.py
+++ b/jovian/tests/utils/test_records.py
@@ -87,17 +87,14 @@ class TestLogMetrics(FakeRecords):
 
     @mock.patch("jovian.utils.records.api.post_block", side_effect=mock_api_post_block)
     def test_log_metrics(self, mock_api_post_block):
-        data = {
-            'acc': 0.89,
-            'val_acc': 0.86
-        }
+        data = { 'acc': 0.89, 'val_acc': 0.86}
         expected_result = [('fake_slug_metrics_1', 'metrics', {}),
                            ('fake_slug_metrics_2', 'metrics', {}),
                            ('fake_slug_hyperparams_1', 'hyperparams', {}),
                            ('fake_slug_hyperparams_2', 'hyperparams', {}),
                            ('fake_slug_3', 'metrics', data)]
 
-        log_metrics(data)
+        log_metrics(acc=0.89, val_acc=0.86)
         self.assertEqual(jovian.utils.records._data_blocks, expected_result)
 
 

--- a/jovian/utils/commit.py
+++ b/jovian/utils/commit.py
@@ -299,7 +299,7 @@ def _perform_git_commit(filename, git_commit, git_message):
 
 def _attach_records(gist_slug, version):
     """Attached records to the current commit"""
-    tracking_slugs = get_records()
+    tracking_slugs = get_records(slug_only=True)
     if len(tracking_slugs) > 0:
         log('Attaching records (metrics, hyperparameters, dataset etc.)')
         api.post_records(gist_slug, tracking_slugs, version)

--- a/jovian/utils/commit.py
+++ b/jovian/utils/commit.py
@@ -7,7 +7,7 @@ from jovian.utils.misc import get_file_extension, is_uuid
 from jovian.utils.rcfile import get_notebook_slug, set_notebook_slug
 from jovian.utils.credentials import read_webapp_url
 from jovian.utils.environment import upload_conda_env, CondaError, upload_pip_env
-from jovian.utils.records import log_git, get_record_slugs, reset_records
+from jovian.utils.records import log_git, get_records, reset
 from jovian.utils.constants import FILENAME_MSG
 from jovian.utils.logger import log
 from jovian.utils import api, git
@@ -282,7 +282,7 @@ def _capture_environment(environment, gist_slug, version):
 
 def _perform_git_commit(filename, git_commit, git_message):
     if git_commit and git.is_git():
-        reset_records('git')  # resets git commit info
+        reset('git')  # resets git commit info
 
         git.commit(git_message)
         log('Git repository identified. Performing git commit...')
@@ -299,7 +299,7 @@ def _perform_git_commit(filename, git_commit, git_message):
 
 def _attach_records(gist_slug, version):
     """Attached records to the current commit"""
-    tracking_slugs = get_record_slugs()
+    tracking_slugs = get_records()
     if len(tracking_slugs) > 0:
-        log('Attaching records (metrics, hyperparameters, datasets, git etc.)')
+        log('Attaching records (metrics, hyperparameters, dataset etc.)')
         api.post_records(gist_slug, tracking_slugs, version)

--- a/jovian/utils/records.py
+++ b/jovian/utils/records.py
@@ -38,8 +38,11 @@ def reset(*record_types):
 def _parse_data(data, data_args):
     """Parse different types of arguments"""
     data = data or {}
-    for k in data_args:
-        data[k] = data_args[k]
+    if type(data) == dict:
+        for k in data_args:
+            data[k] = data_args[k]
+    elif type(data) == list and len(data_args.keys()) > 0:
+        data.append(data_args)
     return data if len(data.keys()) > 0 else None
 
 
@@ -69,6 +72,9 @@ def log_hyperparams(data_dict=None, verbose=True, **data_args):
         verbose(bool, optional): By default it prints the acknowledgement, you can remove 
             this by setting the argument to False.
 
+        **data_args(optional): Instead of passing a dictionary, you can also each each 
+            individual key-value pair as a argument (see example below)
+
     Example
         .. code-block::
 
@@ -84,10 +90,13 @@ def log_metrics(data_dict=None, verbose=True, **data_args):
     """Record metrics for the current experiment
 
     Args:
-        data(dict): A python dict or a array of dicts to be recorded as metrics.
+        data_dict(dict, optional): A python dict to be recorded as metrics.
 
         verbose(bool, optional): By default it prints the acknowledgement, you can remove 
             this by setting the argument to False.
+
+        **data_args(any, optional): Instead of passing a dictionary, you can also each each 
+            individual key-value pair as a argument (see example below)
 
     Example
         .. code-block::
@@ -105,10 +114,13 @@ def log_dataset(data_dict=None, verbose=True, **data_args):
     """Record dataset details for the current experiment
 
     Args:
-        data(dict): A python dict or a array of dicts to be recorded as Dataset.
+        data_dict(dict, optional): A python dict to be recorded as dataset.
 
-        verbose(bool, optional): By default it prints the acknowledgement, you can 
-            remove this by setting the argument to False.
+        verbose(bool, optional): By default it prints the acknowledgement, you can remove 
+            this by setting the argument to False.
+
+        **data_args(optional): Instead of passing a dictionary, you can also each each 
+            individual key-value pair as a argument (see example below)
 
     Example
         .. code-block::

--- a/jovian/utils/records.py
+++ b/jovian/utils/records.py
@@ -4,42 +4,67 @@ from jovian.utils.logger import log
 _data_blocks = []
 
 
-def get_record_slugs(with_type=False):
+def get_records(slug_only=True):
     """Get the list of slugs recorded so far"""
     global _data_blocks
-    if with_type:
-        return _data_blocks
+    if slug_only:
+        return [slug for slug, _, _ in _data_blocks]
     else:
-        return [slug for slug, _ in _data_blocks]
+        return _data_blocks
 
 
-def reset_records(*args):
+def reset(*record_types):
     """Reset the tracked hyperparameters, metrics or dataset (for a fresh experiment)
 
     Args:
-        *args(strings, optional): By default resets all type of records. For specific filter
-                            add keywords `metrics`, `hyperparams`, `dataset` individually
-                            or in combinations to reset those type of records.  
+        *record_types(strings, optional): By default, resets all type of records. 
+            To reset specific type of records, pass arguments `metrics`, 
+            `hyperparams`, `dataset` or `git` 
     Example
         .. code-block::
 
             import jovian
-
-            jovian.reset_records('hyperparams', 'metrics')
+            jovian.reset('hyperparams', 'metrics')
     """
     global _data_blocks
 
-    if len(args) == 0:
+    if len(record_types) == 0:
         _data_blocks = []
     else:
-        _data_blocks = [(slug, rec_type) for (slug, rec_type) in _data_blocks if rec_type not in args]
+        _data_blocks = [(slug, rec_type, data) for (slug, rec_type, data) in _data_blocks
+                        if rec_type not in record_types]
 
 
-def log_hyperparams(data, verbose=True):
+def _parse_data(data, data_args):
+    """Parse different types of arguments"""
+    data = data or {}
+    for k in data_args:
+        data[k] = data_args[k]
+    return data if len(data.keys()) > 0 else None
+
+
+def log_record(record_type, data=None, verbose=True, **data_args):
+    """Create records with the given data & type"""
+    global _data_blocks
+    # Create the combined data dictionary
+    data = _parse_data(data, data_args)
+    if data is None:
+        log('Nothing to record. Skipping..', error=True)
+        return
+    # Send to API endpoint
+    res = api.post_block(data, record_type)
+    tracking_slug = res['tracking']['trackingSlug']
+    # Save to data block
+    _data_blocks.append((tracking_slug, record_type, data))
+    if verbose:
+        log(record_type.capitalize() + ' logged.')
+
+
+def log_hyperparams(data_dict=None, verbose=True, **data_args):
     """Record hyperparameters for the current experiment
 
     Args:
-        data(dict): A python dict or a array of dicts to be recorded as hyperparmeters.
+        data_dict(dict, optional): A python dict to be recorded as hyperparmeters.
 
         verbose(bool, optional): By default it prints the acknowledgement, you can remove 
             this by setting the argument to False.
@@ -48,24 +73,14 @@ def log_hyperparams(data, verbose=True):
         .. code-block::
 
             import jovian
-
-            hyperparams = {
-                'arch_name': 'cnn_1',
-                'lr': .001
-            }
-            jovian.log_hyperparams(hyperparams)
+            jovian.log_hyperparams(arch='cnn', lr=0.001)
+            # or
+            jovian.log_hyperparams({ 'arch': 'cnn', 'lr': 0.001 })
     """
-    global _data_blocks
-    record_type = 'hyperparams'
-
-    res = api.post_block(data, record_type)
-    _data_blocks.append((res['tracking']['trackingSlug'], record_type))
-
-    if verbose:
-        log('Hyperparameters logged.')
+    log_record('hyperparams', data_dict, verbose, **data_args)
 
 
-def log_metrics(data, verbose=True):
+def log_metrics(data_dict=None, verbose=True, **data_args):
     """Record metrics for the current experiment
 
     Args:
@@ -78,26 +93,15 @@ def log_metrics(data, verbose=True):
         .. code-block::
 
             import jovian
-
-            metrics = {
-                'epoch': 1,
-                'train_loss': .5,
-                'val_loss': .3,
-                'acc': .94
-            }
-            jovian.log_metrics(metrics)
+            jovian.log_metrics(epochs=1, train_loss=0.5, 
+                               val_loss=0.3, val_accuracy=0.9)
+            # or
+            jovian.log_metrics({ 'epochs': 1, 'train_loss': 0.5 })
     """
-    global _data_blocks
-    record_type = 'metrics'
-
-    res = api.post_block(data, record_type)
-    _data_blocks.append((res['tracking']['trackingSlug'], record_type))
-
-    if verbose:
-        log('Metrics logged.')
+    log_record('metrics', data_dict, verbose, **data_args)
 
 
-def log_dataset(data, verbose=True):
+def log_dataset(data_dict=None, verbose=True, **data_args):
     """Record dataset details for the current experiment
 
     Args:
@@ -111,23 +115,17 @@ def log_dataset(data, verbose=True):
 
             import jovian
 
-            data = {
-                'path': '/datasets/mnist',
-                'description': '28x28 images of handwritten digits (in grayscale)'
-            }
-            jovian.log_dataset(data)
+            path = 'data/mnist'
+            description = '28x28 images of handwritten digits (in grayscale)'
+
+            jovian.log_dataset(path=path, description=description)
+            # or 
+            jovian.log_dataset({ 'path': path, 'description': description })
     """
-    global _data_blocks
-    record_type = 'dataset'
-
-    res = api.post_block(data, record_type)
-    _data_blocks.append((res['tracking']['trackingSlug'], record_type))
-
-    if verbose:
-        log('Dataset logged.')
+    log_record('dataset', data_dict, verbose, **data_args)
 
 
-def log_git(data, verbose=True):
+def log_git(data_dict=None, verbose=True, **data_args):
     """Record the git-related information.
 
     Args:
@@ -136,11 +134,4 @@ def log_git(data, verbose=True):
         verbose(bool, optional): By default it prints the acknowledgement, you can 
             remove this by setting the argument to False.
     """
-    global _data_blocks
-    record_type = 'git'
-
-    res = api.post_block(data, record_type)
-    _data_blocks.append((res['tracking']['trackingSlug'], record_type))
-
-    if verbose:
-        log('Git information logged.')
+    log_record('git', data_dict, verbose, **data_args)

--- a/jovian/utils/records.py
+++ b/jovian/utils/records.py
@@ -72,7 +72,7 @@ def log_hyperparams(data_dict=None, verbose=True, **data_args):
         verbose(bool, optional): By default it prints the acknowledgement, you can remove 
             this by setting the argument to False.
 
-        **data_args(optional): Instead of passing a dictionary, you can also each each 
+        **data_args(optional): Instead of passing a dictionary, you can also pass each 
             individual key-value pair as a argument (see example below)
 
     Example
@@ -95,7 +95,7 @@ def log_metrics(data_dict=None, verbose=True, **data_args):
         verbose(bool, optional): By default it prints the acknowledgement, you can remove 
             this by setting the argument to False.
 
-        **data_args(any, optional): Instead of passing a dictionary, you can also each each 
+        **data_args(any, optional): Instead of passing a dictionary, you can also pass each 
             individual key-value pair as a argument (see example below)
 
     Example
@@ -119,7 +119,7 @@ def log_dataset(data_dict=None, verbose=True, **data_args):
         verbose(bool, optional): By default it prints the acknowledgement, you can remove 
             this by setting the argument to False.
 
-        **data_args(optional): Instead of passing a dictionary, you can also each each 
+        **data_args(optional): Instead of passing a dictionary, you can also pass each 
             individual key-value pair as a argument (see example below)
 
     Example

--- a/jovian/utils/records.py
+++ b/jovian/utils/records.py
@@ -4,7 +4,7 @@ from jovian.utils.logger import log
 _data_blocks = []
 
 
-def get_records(slug_only=True):
+def get_records(slug_only=False):
     """Get the list of slugs recorded so far"""
     global _data_blocks
     if slug_only:

--- a/jovian/utils/records.py
+++ b/jovian/utils/records.py
@@ -51,7 +51,7 @@ def log_record(record_type, data=None, verbose=True, **data_args):
     global _data_blocks
     # Create the combined data dictionary
     data = _parse_data(data, data_args)
-    if data is None:
+    if data is None and verbose:
         log('Nothing to record. Skipping..', error=True)
         return
     # Send to API endpoint


### PR DESCRIPTION
Instead of passing dictionary, you can simply pass in named arguments.

```
import jovian
jovian.log_hyperparams(arch='cnn', lr=0.001)
# or
jovian.log_hyperparams({ 'arch': 'cnn', 'lr': 0.001 })
```

Also renamed `reset_records` back to `reset` (to avoid breaking backward compatibility).