### PR TITLE
Add html context for edit on github links

### DIFF
--- a/docs/_static/css/override.css
+++ b/docs/_static/css/override.css
@@ -2,7 +2,7 @@
 @import "navbar.css";
 
 /* Load fonts */
-@import url("https://fonts.googleapis.com/css?family=Lato|Roboto+Mono|Roboto:400,500&display=swap");
+@import url("https://fonts.googleapis.com/css?family=Roboto+Mono|Roboto:400,500&display=fallback");
 
 body,
 html,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,15 @@ html_theme_options = {
     'sticky_navigation': False
 }
 
+html_context = {
+    'display_github': True,
+    'github_user': 'JovianML',
+    'github_repo': 'jovian-py',
+    'github_version': 'master',
+    'conf_py_path': '/docs/'
+}
+
+
 def setup(app):
     """Enables to embed reStructuredText(rst) in a markdown(.md)
 


### PR DESCRIPTION
- stop loading Lato (part of theme.css)
- use fallback display for font