### PR TITLE
added overwrite flag to clone

### DIFF
--- a/jovian/cli.py
+++ b/jovian/cli.py
@@ -101,8 +101,9 @@ def activate_env(ctx):
 @click.argument('notebook')
 @click.option('-v', '--version', 'version')
 @click.option('--no-outputs', 'no_outputs')
+@click.option('--overwrite', 'overwrite', is_flag=True)
 @click.pass_context
-def exec_clone(ctx, notebook, version, no_outputs):
+def exec_clone(ctx, notebook, version, no_outputs, overwrite):
     """Clone a notebook hosted on Jovian:
 
         $ jovian clone aakashns/jovian-tutorial
@@ -112,7 +113,7 @@ def exec_clone(ctx, notebook, version, no_outputs):
         $ jovian clone aakashns/jovian-tutorial -v 10
     """
 
-    clone(notebook, version, not no_outputs)
+    clone(notebook, version, not no_outputs, overwrite=overwrite)
 
 
 @main.command("pull", short_help="Fetch new version of notebook hosted Jovian.")

--- a/jovian/cli.py
+++ b/jovian/cli.py
@@ -113,7 +113,7 @@ def exec_clone(ctx, notebook, version, no_outputs, overwrite):
         $ jovian clone aakashns/jovian-tutorial -v 10
     """
 
-    clone(notebook, version, not no_outputs, overwrite=overwrite)
+    clone(notebook, version, include_outputs=not no_outputs, overwrite=overwrite)
 
 
 @main.command("pull", short_help="Fetch new version of notebook hosted Jovian.")

--- a/jovian/utils/clone.py
+++ b/jovian/utils/clone.py
@@ -87,8 +87,8 @@ def clone(slug, version=None, fresh=True, include_outputs=True, overwrite=False)
         while os.path.exists(title + '-' + str(i)):
             i += 1
         title = title + '-' + str(i)
-        if not os.path.exists(title):
-            os.makedirs(title)
+
+        os.makedirs(title)
         os.chdir(title)
 
     # Download the files

--- a/jovian/utils/clone.py
+++ b/jovian/utils/clone.py
@@ -75,13 +75,18 @@ def clone(slug, version=None, fresh=True, include_outputs=True, overwrite=False)
     title = gist['title']
 
     # If fresh clone, create directory
-    if fresh:
-        if os.path.exists(title):
-            if not overwrite:
-                i = 1
-                while os.path.exists(title + '-' + str(i)):
-                    i += 1
-                title = title + '-' + str(i)
+    if fresh and not os.path.exists(title):
+        os.makedirs(title)
+        os.chdir(title)
+
+    elif fresh and os.path.exists(title) and overwrite:
+        os.chdir(title)
+
+    elif fresh and os.path.exists(title) and not overwrite:
+        i = 1
+        while os.path.exists(title + '-' + str(i)):
+            i += 1
+        title = title + '-' + str(i)
         if not os.path.exists(title):
             os.makedirs(title)
         os.chdir(title)
@@ -98,10 +103,8 @@ def clone(slug, version=None, fresh=True, include_outputs=True, overwrite=False)
             set_notebook_slug(f['filename'], slug)
 
     # Print success message and instructions
-    if fresh and not overwrite:
+    if fresh:
         post_clone_msg(title)
-    elif overwrite:
-        log(f'Downloaded files into {title}')
     else:
         log('Files dowloaded successfully in current directory')
 

--- a/jovian/utils/clone.py
+++ b/jovian/utils/clone.py
@@ -63,7 +63,7 @@ so please make sure you have it installed and added to path.
 """, pre=False)
 
 
-def clone(slug, version=None, fresh=True, include_outputs=True):
+def clone(slug, version=None, fresh=True, include_outputs=True, overwrite=False):
     """Download the files for a gist"""
     # Print issues link
     log(ISSUES_MSG)
@@ -77,10 +77,11 @@ def clone(slug, version=None, fresh=True, include_outputs=True):
     # If fresh clone, create directory
     if fresh:
         if os.path.exists(title):
-            i = 1
-            while os.path.exists(title + '-' + str(i)):
-                i += 1
-            title = title + '-' + str(i)
+            if not overwrite:
+                i = 1
+                while os.path.exists(title + '-' + str(i)):
+                    i += 1
+                title = title + '-' + str(i)
         if not os.path.exists(title):
             os.makedirs(title)
         os.chdir(title)
@@ -97,8 +98,10 @@ def clone(slug, version=None, fresh=True, include_outputs=True):
             set_notebook_slug(f['filename'], slug)
 
     # Print success message and instructions
-    if fresh:
+    if fresh and not overwrite:
         post_clone_msg(title)
+    elif overwrite:
+        log(f'Downloaded files into {title}')
     else:
         log('Files dowloaded successfully in current directory')
 


### PR DESCRIPTION
With `--overwrite` flag, you can now do:

`jovian clone user/projectname --overwrite` and it will overwrite the folder `projectname`. 

and fixed `include_outputs` CLI option.
