### PR TITLE
Implemented file extension whitelist

### DIFF
--- a/jovian/utils/commit.py
+++ b/jovian/utils/commit.py
@@ -267,15 +267,15 @@ def _attach_files(paths, gist_slug, version, output=False, exclude_files=None):
             if os.path.isdir(f) or os.path.splitext(f)[1] in EXTENSION_WHITELIST
         ]
 
-        if exclude_files:
-            if not isinstance(exclude_files, list):
-                exclude_files = [exclude_files]
+    if exclude_files:
+        if not isinstance(exclude_files, list):
+            exclude_files = [exclude_files]
 
-            for filename in exclude_files:
-                try:
-                    paths.remove(filename)
-                except ValueError:
-                    pass
+        for filename in exclude_files:
+            try:
+                paths.remove(filename)
+            except ValueError:
+                pass
 
     log('Uploading additional ' + ('outputs' if output else 'files') + '...')
 

--- a/jovian/utils/commit.py
+++ b/jovian/utils/commit.py
@@ -251,7 +251,7 @@ def _attach_file(path, gist_slug, version, output=False):
 
 def _attach_files(paths, gist_slug, version, output=False, exclude_files=None):
     """Helper functions to attach files & folders to a commit"""
-    config = get_config()
+    config = read_creds().get("DEFAULT_CONFIG", {})
 
     EXTENSION_WHITELIST = config.get("EXTENSION_WHITELIST", DEFAULT_EXTENSION_WHITELIST)
     UPLOAD_WD = config.get("UPLOAD_WORKING_DIRECTORY", False)

--- a/jovian/utils/commit.py
+++ b/jovian/utils/commit.py
@@ -264,7 +264,7 @@ def _attach_files(paths, gist_slug, version, output=False, exclude_files=None):
         paths = [
             f
             for f in glob.glob('**/*', recursive=True)
-            if os.path.isdir(f) or get_file_extension(f) in EXTENSION_WHITELIST
+            if os.path.isdir(f) or os.path.splitext(f)[1] in EXTENSION_WHITELIST
         ]
 
         if exclude_files:
@@ -272,7 +272,10 @@ def _attach_files(paths, gist_slug, version, output=False, exclude_files=None):
                 exclude_files = [exclude_files]
 
             for filename in exclude_files:
-                paths.remove(filename)
+                try:
+                    paths.remove(filename)
+                except ValueError:
+                    pass
 
     log('Uploading additional ' + ('outputs' if output else 'files') + '...')
 

--- a/jovian/utils/commit.py
+++ b/jovian/utils/commit.py
@@ -4,7 +4,7 @@ from time import sleep
 
 from jovian.utils.script import in_script, get_script_filename
 from jovian.utils.jupyter import in_notebook, get_notebook_name, save_notebook
-from jovian.utils.misc import get_file_extension, is_uuid, get_config
+from jovian.utils.misc import get_file_extension, is_uuid
 from jovian.utils.rcfile import get_notebook_slug, set_notebook_slug
 from jovian.utils.credentials import read_webapp_url, read_creds
 from jovian.utils.environment import upload_conda_env, CondaError, upload_pip_env

--- a/jovian/utils/constants.py
+++ b/jovian/utils/constants.py
@@ -20,4 +20,4 @@ DEFAULT_ORG_ID = "public"
 CONDA_NOT_FOUND = 'Anaconda binary not found. Please make sure the "conda" command is in your ' \
                   'system PATH or the environment variable $CONDA_EXE points to the anaconda binary'
 
-EXTENSION_WHITELIST = [".ipynb", ".yml", ".yaml", ".py", ".txt", ". csv", ".tsv"]
+DEFAULT_EXTENSION_WHITELIST = [".ipynb", ".yml", ".yaml", ".py", ".txt", ". csv", ".tsv"]

--- a/jovian/utils/constants.py
+++ b/jovian/utils/constants.py
@@ -19,3 +19,5 @@ DEFAULT_ORG_ID = "public"
 
 CONDA_NOT_FOUND = 'Anaconda binary not found. Please make sure the "conda" command is in your ' \
                   'system PATH or the environment variable $CONDA_EXE points to the anaconda binary'
+
+EXTENSION_WHITELIST = [".ipynb", ".yml", ".yaml", ".py", ".txt", ". csv", ".tsv"]

--- a/jovian/utils/misc.py
+++ b/jovian/utils/misc.py
@@ -2,6 +2,7 @@ import time
 import platform
 
 from uuid import UUID
+from jovian.utils.credentials import read_creds
 from jovian.utils.constants import LINUX, WINDOWS, MACOS
 from jovian._version import __version__
 
@@ -65,3 +66,7 @@ def urljoin(*args):
 
 def version():
     return __version__
+
+def get_config():
+    creds = read_creds()
+    return creds.get("DEFAULT_CONFIG", {})

--- a/jovian/utils/misc.py
+++ b/jovian/utils/misc.py
@@ -66,7 +66,3 @@ def urljoin(*args):
 
 def version():
     return __version__
-
-def get_config():
-    creds = read_creds()
-    return creds.get("DEFAULT_CONFIG", {})

--- a/jovian/utils/misc.py
+++ b/jovian/utils/misc.py
@@ -2,7 +2,6 @@ import time
 import platform
 
 from uuid import UUID
-from jovian.utils.credentials import read_creds
 from jovian.utils.constants import LINUX, WINDOWS, MACOS
 from jovian._version import __version__
 


### PR DESCRIPTION
Default whitelist is `[".ipynb", ".yml", ".yaml", ".py", ".txt", ". csv", ".tsv"]` 

To override it, set custom whitelist in `"DEFAULT_CONFIG"` of  `credentials.json`.

Also, refactored the code to make it more readable.