### PR TITLE
Update badge links

### DIFF
--- a/.github/workflows/pythonapp35.yml
+++ b/.github/workflows/pythonapp35.yml
@@ -31,14 +31,3 @@ jobs:
           git config --global user.name ${GITHUB_NAME}
           pip install pytest
           pytest
-      - name: Generate coverage report
-        run: |
-          pip install pytest-cov
-          python -m pytest -W ignore::DeprecationWarning --cov-config .coveragerc --cov-report xml --cov=jovian jovian/tests
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage.xml
-          flags: unittests
-          name: codecov-umbrella
-          fail_ci_if_error: true

--- a/.github/workflows/pythonapp38.yml
+++ b/.github/workflows/pythonapp38.yml
@@ -29,14 +29,3 @@ jobs:
           git config --global user.name ${GITHUB_NAME}
           pip install pytest
           pytest
-      - name: Generate coverage report
-        run: |
-          pip install pytest-cov
-          python -m pytest -W ignore::DeprecationWarning --cov-config .coveragerc --cov-report xml --cov=jovian jovian/tests
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage.xml
-          flags: unittests
-          name: codecov-umbrella
-          fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 ![](/docs/jovian_horizontal_logo.svg)
 
 [![Documentation Status](https://readthedocs.org/projects/jovian-py/badge/?version=latest)](https://jovian.ml/docs/)
-![Python application](https://github.com/JovianML/jovian-py/workflows/Python%20application/badge.svg)
-![Code](https://codecov.io/gh/JovianML/jovian-py/branch/unit-testing-5/graph/badge.svg)
+![Python application](https://github.com/JovianML/jovian-py/workflows/Python%20application/badge.svg)]
+[![Code Coverage](https://codecov.io/gh/JovianML/jovian-py/branch/master/graph/badge.svg)](https://codecov.io/gh/JovianML/jovian-py)
+
 
 [Jovian.ml](https://www.jovian.ml?utm_source) is a platform for sharing and collaboraring on Jupyter notebooks and data science projects. `jovian-py` is an open-source Python package for uploading your data science code, Jupyter notebooks, ML models, hyperparameters, metrics etc. to your Jovian.ml account. 
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![](/docs/jovian_horizontal_logo.svg)
 
 [![Documentation Status](https://readthedocs.org/projects/jovian-py/badge/?version=latest)](https://jovian.ml/docs/)
-![Python application](https://github.com/JovianML/jovian-py/workflows/Python%20application/badge.svg)]
+[![Python application](https://github.com/JovianML/jovian-py/workflows/Python%20application/badge.svg)](https://github.com/JovianML/jovian-py/actions?query=branch%3Amaster)
 [![Code Coverage](https://codecov.io/gh/JovianML/jovian-py/branch/master/graph/badge.svg)](https://codecov.io/gh/JovianML/jovian-py)
 
 


### PR DESCRIPTION
Changes:
- Updated badge links
  - Python Application badge now points to action page
  - Code coverage badge now points to https://codecov.io/gh/JovianML/jovian-py

- Removed code coverage reporting from builds of Python 3.5 and Python 3.8 as it does **not** hit 100%, hence PRs will have a code coverage failed status for quite some time before the Python 3.6, 3.7 builds finally bring the coverage up to 100%.