### PR TITLE
change bright_red to red in logger

### DIFF
--- a/jovian/utils/logger.py
+++ b/jovian/utils/logger.py
@@ -5,6 +5,6 @@ import click
 def log(msg, pre=True, error=False, color=None):
     """Print a message to stdout"""
     if error:
-        click.secho(('[jovian] ' if pre else '') + 'Error: ' + msg, err=True, fg='bright_red')
+        click.secho(('[jovian] ' if pre else '') + 'Error: ' + msg, err=True, fg='red')
     else:
         click.echo(('[jovian] ' if pre else '') + click.style(msg, fg=color))


### PR DESCRIPTION
`bright_red` color during error logs was causing issue on Windows, changed to just `red`.

Basic ANSI colors: https://www.lihaoyi.com/post/BuildyourownCommandLinewithANSIescapecodes.html#8-colors