### PR TITLE
fix environment capture on windows

### DIFF
--- a/jovian/tests/utils/test_environment.py
+++ b/jovian/tests/utils/test_environment.py
@@ -61,22 +61,17 @@ def test_get_conda_bin_look_for_conda_exe_raises_error(mock_popen):
         get_conda_bin()
 
 
-@mock.patch("os.popen")
-def test_get_conda_env_name(mock_popen):
-    mock_popen().read().strip.return_value = 'fake-env'
-    assert get_conda_env_name() == 'fake-env'
-
-
-@mock.patch("os.popen")
-def test_get_conda_env_name_base(mock_popen):
-    mock_popen().read().strip.return_value = ''
-    assert get_conda_env_name() == 'base'
-
-
-@mock.patch("os.popen")
-def test_get_conda_env_name_echo_conda_default_env(mock_popen):
-    mock_popen().read().strip.return_value = '$CONDA_DEFAULT_ENV'
-    assert get_conda_env_name() == 'base'
+@pytest.mark.parametrize(
+    "env_dict, expected_result",
+    [
+        ({"CONDA_DEFAULT_ENV": "fake-env"}, "fake-env"),
+        ({"CONDA_DEFAULT_ENV": ""}, "base"),
+        ({}, "base")
+    ]
+)
+def test_get_conda_env_name(env_dict, expected_result):
+    with mock.patch.dict("os.environ", env_dict, clear=True):
+        assert get_conda_env_name() == expected_result
 
 
 @mock.patch("jovian.utils.environment.get_conda_env_name", return_value='fake-env')

--- a/jovian/tests/utils/test_environment.py
+++ b/jovian/tests/utils/test_environment.py
@@ -31,33 +31,20 @@ ENV_STR = dedent("""
         """).strip()
 
 
-@mock.patch("os.popen")
-def test_get_conda_bin(mock_popen):
-    ret1 = mock.Mock()
-    ret1.read().strip.return_value = 'usage: conda [-h] [-V] command ...'
-    mock_popen.side_effect = [ret1, ret1]
-    assert get_conda_bin() == 'conda'
+def test_get_conda_bin():
+    with mock.patch.dict("os.environ", {"CONDA_EXE": "/Users/username/miniconda3/bin/conda"}, clear=True):
+        assert get_conda_bin() == "/Users/username/miniconda3/bin/conda"
 
 
-@mock.patch("os.popen")
-def test_get_conda_bin_look_for_conda_exe(mock_popen):
-    ret1, ret2, ret3 = mock.Mock(), mock.Mock(), mock.Mock()
-    ret1.read().strip.return_value = ''
-    ret2.read().strip.return_value = '/usr/bin/conda'
-    ret3.read().strip.return_value = 'usage: conda [-h] [-V] command ...'
-    mock_popen.side_effect = [ret1, ret2, ret3]
-
-    assert get_conda_bin() == '/usr/bin/conda'
-
-
-@mock.patch("os.popen")
-def test_get_conda_bin_look_for_conda_exe_raises_error(mock_popen):
-    ret1, ret2 = mock.Mock(), mock.Mock()
-    ret1.read().strip.return_value = ''
-    ret2.read().strip.return_value = '/Users/rohitsanjay/miniconda3/bin/conda'
-    mock_popen.side_effect = [ret1, ret2, ret1]
-
-    with pytest.raises(CondaError):
+@pytest.mark.parametrize(
+    "env_dict",
+    [
+        {"CONDA_EXE": ""},
+        {}
+    ]
+)
+def test_get_conda_bin_raises_error(env_dict):
+    with mock.patch.dict("os.environ", env_dict, clear=True), pytest.raises(CondaError):
         get_conda_bin()
 
 

--- a/jovian/utils/environment.py
+++ b/jovian/utils/environment.py
@@ -10,19 +10,9 @@ from jovian.utils.error import CondaError
 
 def get_conda_bin():
     """Get the path to the Anaconda binary"""
-    conda_bin = 'conda'
-    # Try executing the `conda` command
-    if os.popen(conda_bin).read().strip() == '':
-        # If it fails, look for $CONDA_EXE
-        conda_exe = os.popen('echo $CONDA_EXE').read().strip()
-        # Check if it returns a valid path
-        if conda_exe != '' and conda_exe != '$CONDA_EXE':
-            # Update binary and execute again
-            conda_bin = conda_exe
-
-    if os.popen(conda_bin).read().strip() == '':
+    conda_bin = os.environ.get("CONDA_EXE")
+    if not conda_bin:
         raise CondaError(CONDA_NOT_FOUND)
-
     logging.info('Anaconda binary: ' + conda_bin)
     return conda_bin
 

--- a/jovian/utils/environment.py
+++ b/jovian/utils/environment.py
@@ -29,9 +29,7 @@ def get_conda_bin():
 
 def get_conda_env_name():
     """Get the name of the active conda environment"""
-    env_name = os.popen('echo $CONDA_DEFAULT_ENV').read().strip()
-    if env_name == '' or env_name == '$CONDA_DEFAULT_ENV':
-        env_name = 'base'
+    env_name = os.environ.get("CONDA_DEFAULT_ENV", "base")
     logging.info('Anaconda environment: ' + env_name)
     return env_name
 

--- a/jovian/utils/environment.py
+++ b/jovian/utils/environment.py
@@ -30,6 +30,10 @@ def get_conda_bin():
 def get_conda_env_name():
     """Get the name of the active conda environment"""
     env_name = os.environ.get("CONDA_DEFAULT_ENV", "base")
+
+    if not env_name:
+        env_name = "base"
+
     logging.info('Anaconda environment: ' + env_name)
     return env_name
 

--- a/jovian/utils/environment.py
+++ b/jovian/utils/environment.py
@@ -30,10 +30,8 @@ def get_conda_bin():
 def get_conda_env_name():
     """Get the name of the active conda environment"""
     env_name = os.environ.get("CONDA_DEFAULT_ENV", "base")
-
     if not env_name:
         env_name = "base"
-
     logging.info('Anaconda environment: ' + env_name)
     return env_name
 


### PR DESCRIPTION
Used `os.environ` to get the name of conda environment instead of executing an echo command and capturing the output.