### PR TITLE
Pass args to kaggle commit, handle / in project

### DIFF
--- a/jovian/tests/utils/test_kaggle.py
+++ b/jovian/tests/utils/test_kaggle.py
@@ -1,0 +1,98 @@
+from unittest import mock
+import pytest
+from textwrap import dedent
+from jovian.utils.kaggle import perform_kaggle_commit
+from jovian.tests.resources.shared import fake_creds
+
+
+@pytest.mark.parametrize("args, expected_jovian_commit",
+                         [
+                             # default commit params w/ full project name
+                             ({'message': None,
+                               'files': [],
+                               'outputs': [],
+                               'environment': 'auto',
+                               'privacy': 'auto',
+                               'project': 'PrajwalPrasahanth/sample-notebook',
+                               'new_project': None},
+                              """jovian.commit(message=None, files=[], outputs=[], environment='auto', privacy='auto', filename='sample-notebook.ipynb', project='PrajwalPrasahanth/sample-notebook', new_project=None)"""),
+                             # default commit params w/ just project title
+                             ({'message': None,
+                               'files': [],
+                               'outputs': [],
+                               'environment': 'auto',
+                               'privacy': 'auto',
+                               'project': 'sample-notebook',
+                               'new_project': None},
+                              """jovian.commit(message=None, files=[], outputs=[], environment='auto', privacy='auto', filename='sample-notebook.ipynb', project='sample-notebook', new_project=None)"""),
+                             # message is string, environment in None, new_project is bool
+                             ({'message': "test commit",
+                               'files': [],
+                               'outputs': [],
+                               'environment': None,
+                               'privacy': 'auto',
+                               'project': 'sample-notebook',
+                               'new_project': True},
+                              """jovian.commit(message='test commit', files=[], outputs=[], environment=None, privacy='auto', filename='sample-notebook.ipynb', project='sample-notebook', new_project=True)""")
+                         ])
+@ mock.patch('jovian.utils.kaggle.get_ipython')
+@ mock.patch("jovian.utils.kaggle.get_current_user", return_value={'username': 'PrajwalPrashanth'})
+def test_perform_kaggle_commit(mock_get_current_user, mock_get_ipython, args, expected_jovian_commit):
+
+    perform_kaggle_commit(**args)
+
+    # expected
+    filename = "sample-notebook.ipynb"  # expected filename remains constant for all tests
+    jovian_commit = expected_jovian_commit
+
+    # js_code from jovian.utils.kaggle
+    js_code = '''
+    require(["base/js/namespace"],function(Jupyter) {
+        var nbJson = JSON.stringify(Jupyter.notebook.toJSON());
+
+        console.log("[jovian] Extracted notebook JSON:");
+        console.log(nbJson);
+
+        function jvnLog (data) {
+          console.log("Result from jovian.commit:");
+          if (data.content.text) {
+              var result = JSON.parse(data.content.text.trim());
+              var msg = result['msg'];
+              var err = result['err'];
+              if (msg) {
+                  element.text("Committed successfully: " + msg)
+              } else {
+                  alert("Notebook commit failed. Error: " + (err || "Unknown"))
+              }
+          }
+          
+        };
+        
+        var pythonCode = `
+from contextlib import redirect_stdout, redirect_stderr
+from io import StringIO
+import json
+ 
+with open("'''+filename+'''", 'w') as f:
+    f.write(r"""${nbJson}""")
+
+jvn_update = StringIO()
+jvn_update_err = StringIO()
+with redirect_stdout(jvn_update), redirect_stderr(jvn_update_err):
+    from jovian import commit
+
+jvn_f_out = StringIO()
+jvn_f_err = StringIO()
+with redirect_stdout(jvn_f_out), redirect_stderr(jvn_f_err):
+    jvn_msg = '''+jovian_commit+'''
+
+print(json.dumps({'msg': jvn_msg, 'err': jvn_f_err.getvalue(), 'update': jvn_update.getvalue()}))
+        `;
+
+        console.log("Invoking jovian.commit")
+        // console.log(pythonCode)
+
+        Jupyter.notebook.kernel.execute(pythonCode, { iopub: { output: jvnLog }});
+    });'''
+
+    mock_get_ipython().run_cell_magic.assert_called_with('javascript', '', js_code)

--- a/jovian/utils/commit.py
+++ b/jovian/utils/commit.py
@@ -146,7 +146,13 @@ def commit(message=None,
             log("Please provide the project argument e.g. jovian.commit(project='my-project')", error=True)
             return
 
-        perform_kaggle_commit(project)
+        perform_kaggle_commit(message, 
+                            files, 
+                            outputs, 
+                            environment,
+                            privacy,
+                            project,
+                            new_project)
         return
 
     # Ensure that the file exists

--- a/jovian/utils/commit.py
+++ b/jovian/utils/commit.py
@@ -139,8 +139,6 @@ def commit(message=None,
         log(FILENAME_MSG, error=True)
         return
 
-    print(message, files, outputs, environment, privacy, filename, project, new_project)
-
     # Commit from Kaggle (After many bug reports of empty notebook)
     if filename == '__notebook_source__.ipynb':
         log("Detected Kaggle notebook...")

--- a/jovian/utils/commit.py
+++ b/jovian/utils/commit.py
@@ -139,6 +139,8 @@ def commit(message=None,
         log(FILENAME_MSG, error=True)
         return
 
+    print(message, files, outputs, environment, privacy, filename, project, new_project)
+
     # Commit from Kaggle (After many bug reports of empty notebook)
     if filename == '__notebook_source__.ipynb':
         log("Detected Kaggle notebook...")
@@ -146,13 +148,13 @@ def commit(message=None,
             log("Please provide the project argument e.g. jovian.commit(project='my-project')", error=True)
             return
 
-        perform_kaggle_commit(message, 
-                            files, 
-                            outputs, 
-                            environment,
-                            privacy,
-                            project,
-                            new_project)
+        perform_kaggle_commit(message,
+                              files,
+                              outputs,
+                              environment,
+                              privacy,
+                              project,
+                              new_project)
         return
 
     # Ensure that the file exists

--- a/jovian/utils/kaggle.py
+++ b/jovian/utils/kaggle.py
@@ -28,22 +28,8 @@ def perform_kaggle_commit(message,
     filename = project + ".ipynb"
 
     # Construct jovian.commit w/ parameters
-    jovian_commit = """jovian.commit(message='{}', 
-                                    files='{}', 
-                                    outputs='{}',
-                                    environment='{}',
-                                    privacy='{}',
-                                    filename='{}',
-                                    project='{}',
-                                    new_project='{}'
-                                    )""".format(message,
-                                                files,
-                                                outputs,
-                                                environment,
-                                                privacy,
-                                                filename,
-                                                project,
-                                                new_project)
+    jovian_commit = """jovian.commit(message='{}', files={}, outputs={}, environment='{}', privacy='{}', filename='{}', project='{}', new_project={})""".format(
+        message, files, outputs, environment, privacy, filename, project, new_project)
 
     print(jovian_commit)
 

--- a/jovian/utils/kaggle.py
+++ b/jovian/utils/kaggle.py
@@ -9,7 +9,13 @@ from jovian.utils.credentials import read_cred, WEBAPP_URL_KEY
 from jovian.utils.constants import DEFAULT_WEBAPP_URL
 
 
-def perform_kaggle_commit(project):
+def perform_kaggle_commit(message,
+                          files,
+                          outputs,
+                          environment,
+                          privacy,
+                          project,
+                          new_project):
     """ Retreive all cells and writes it to a file called project-name.ipynb, then returns the filename"""
     # Get user profile
     user = get_current_user()['username']
@@ -21,7 +27,27 @@ def perform_kaggle_commit(project):
     # Construct filename
     filename = project + ".ipynb"
 
-    # Consturct javascript code
+    # Construct jovian.commit w/ parameters
+    jovian_commit = """jovian.commit(message='{}', 
+                                    files='{}', 
+                                    outputs='{}',
+                                    environment='{}',
+                                    privacy='{}',
+                                    filename='{}',
+                                    project='{}',
+                                    new_project='{}'
+                                    )""".format(message,
+                                                files,
+                                                outputs,
+                                                environment,
+                                                privacy,
+                                                filename,
+                                                project,
+                                                new_project)
+
+    print(jovian_commit)
+
+    # Construct javascript code
     js_code = '''
     require(["base/js/namespace"],function(Jupyter) {
         var nbJson = JSON.stringify(Jupyter.notebook.toJSON());
@@ -60,13 +86,13 @@ with redirect_stdout(jvn_update), redirect_stderr(jvn_update_err):
 jvn_f_out = StringIO()
 jvn_f_err = StringIO()
 with redirect_stdout(jvn_f_out), redirect_stderr(jvn_f_err):
-    jvn_msg = jovian.commit(project="'''+project+'''", filename="'''+filename+'''", environment=None)
+    jvn_msg = '''+jovian_commit+'''
 
 print(json.dumps({'msg': jvn_msg, 'err': jvn_f_err.getvalue(), 'update': jvn_update.getvalue()}))
         `;
 
         console.log("Invoking jovian.commit")
-        // console.log(pythonCode)
+        console.log(pythonCode)
 
         Jupyter.notebook.kernel.execute(pythonCode, { iopub: { output: jvnLog }});
     });'''

--- a/jovian/utils/kaggle.py
+++ b/jovian/utils/kaggle.py
@@ -25,13 +25,11 @@ def perform_kaggle_commit(message,
     log("Uploading notebook to " + url)
 
     # Construct filename
-    filename = project + ".ipynb"
+    filename = "{}.ipynb".format(project.split('/')[1] if '/' in project else project)
 
-    # Handle str, None, list accordingly
+    # Handle str, None accordingly
     message = "'{}'".format(message) if isinstance(message, str) else None
     environment = "'{}'".format(environment) if isinstance(environment, str) else None
-    files = "'{}'".format(files) if isinstance(files, str) else files
-    outputs = "'{}'".format(outputs) if isinstance(outputs, str) else outputs
 
     # Construct jovian.commit w/ parameters
     jovian_commit = """jovian.commit(message={}, files={}, outputs={}, environment={}, privacy='{}', filename='{}', project='{}', new_project={})""".format(

--- a/jovian/utils/kaggle.py
+++ b/jovian/utils/kaggle.py
@@ -35,8 +35,6 @@ def perform_kaggle_commit(message,
     jovian_commit = """jovian.commit(message={}, files={}, outputs={}, environment={}, privacy='{}', filename='{}', project='{}', new_project={})""".format(
         message, files, outputs, environment, privacy, filename, project, new_project)
 
-    print(jovian_commit)
-
     # Construct javascript code
     js_code = '''
     require(["base/js/namespace"],function(Jupyter) {
@@ -82,7 +80,7 @@ print(json.dumps({'msg': jvn_msg, 'err': jvn_f_err.getvalue(), 'update': jvn_upd
         `;
 
         console.log("Invoking jovian.commit")
-        console.log(pythonCode)
+        // console.log(pythonCode)
 
         Jupyter.notebook.kernel.execute(pythonCode, { iopub: { output: jvnLog }});
     });'''

--- a/jovian/utils/kaggle.py
+++ b/jovian/utils/kaggle.py
@@ -27,8 +27,14 @@ def perform_kaggle_commit(message,
     # Construct filename
     filename = project + ".ipynb"
 
+    # Handle str, None, list accordingly
+    message = "'{}'".format(message) if isinstance(message, str) else None
+    environment = "'{}'".format(environment) if isinstance(environment, str) else None
+    files = "'{}'".format(files) if isinstance(files, str) else files
+    outputs = "'{}'".format(outputs) if isinstance(outputs, str) else outputs
+
     # Construct jovian.commit w/ parameters
-    jovian_commit = """jovian.commit(message='{}', files={}, outputs={}, environment='{}', privacy='{}', filename='{}', project='{}', new_project={})""".format(
+    jovian_commit = """jovian.commit(message={}, files={}, outputs={}, environment={}, privacy='{}', filename='{}', project='{}', new_project={})""".format(
         message, files, outputs, environment, privacy, filename, project, new_project)
 
     print(jovian_commit)


### PR DESCRIPTION
- [x] Fix '/' in project bug for kaggle commit
- [x] Pass args to kaggle commit. | **passed** message, files outputs, environment, privacy, project, new_project | **Excluded** git_commit, git_message, filename 
- [x] Handle str and None to retain format for message and environment