### PR TITLE
get_conda_bin fix

### DIFF
--- a/jovian/tests/utils/test_environment.py
+++ b/jovian/tests/utils/test_environment.py
@@ -50,7 +50,7 @@ def test_get_conda_bin_look_for_conda_exe(mock_popen):
     assert get_conda_bin() == "/Users/username/miniconda3/bin/conda"
 
 
-@mock.patch.dict("os.environ", "")
+@mock.patch.dict("os.environ", {"CONDA_EXE": "/Users/username/miniconda3/bin/conda"})
 @mock.patch("os.popen")
 def test_get_conda_bin_look_for_conda_exe_raises_error(mock_popen):
     ret1, ret2 = mock.Mock(), mock.Mock()

--- a/jovian/utils/environment.py
+++ b/jovian/utils/environment.py
@@ -16,7 +16,7 @@ def get_conda_bin():
         # If it fails, look for $CONDA_EXE
         conda_exe = os.environ.get("CONDA_EXE")
         # Check if it returns a valid path
-        if conda_exe is not None and conda_exe != '$CONDA_EXE':
+        if conda_exe and conda_exe != '$CONDA_EXE':
             # Update binary and execute again
             conda_bin = conda_exe
             if os.popen(conda_bin).read().strip() == '':

--- a/jovian/utils/environment.py
+++ b/jovian/utils/environment.py
@@ -16,7 +16,7 @@ def get_conda_bin():
         # If it fails, look for $CONDA_EXE
         conda_exe = os.environ.get("CONDA_EXE")
         # Check if it returns a valid path
-        if conda_exe != '' and conda_exe != '$CONDA_EXE':
+        if conda_exe is not None and conda_exe != '$CONDA_EXE':
             # Update binary and execute again
             conda_bin = conda_exe
             if os.popen(conda_bin).read().strip() == '':


### PR DESCRIPTION
**Reported Issue** https://jovian.ml/forum/t/jovian-commit-not-working/7367

```
        conda_exe = os.environ.get("CONDA_EXE")
        # Check if it returns a valid path
        if conda_exe != '' and conda_exe != '$CONDA_EXE':
```

Previous check was for empty string where as `conda_exe` would be None if it did not find a valid path