### PR TITLE
Support attaching Files, Records, Env for Colab commit

### DIFF
--- a/jovian/utils/commit.py
+++ b/jovian/utils/commit.py
@@ -130,10 +130,9 @@ def commit(message=None,
             log("Please provide the project argument e.g. jovian.commit(project='my-project')", error=True)
             return
         if environment == "conda":
-            log("Colab uses a pip environment, cannot capture conda environment.", error=True)
-            return
-        elif environment == "auto":
-            environment = "pip"
+            log("Colab uses a pip environment, cannot capture conda environment. Capturing pip environment", error=True)
+
+        environment = "pip"
 
         res = perform_colab_commit(project, privacy)
         slug, username, version, title = res['slug'], res['owner']['username'], res['version'], res['title']

--- a/jovian/utils/commit.py
+++ b/jovian/utils/commit.py
@@ -130,7 +130,7 @@ def commit(message=None,
             log("Please provide the project argument e.g. jovian.commit(project='my-project')", error=True)
             return
         if environment == "conda":
-            log("Colab uses a pip environment, cannot capture conda environment.")
+            log("Colab uses a pip environment, cannot capture conda environment.", error=True)
             return
         elif environment == "auto":
             environment = "pip"

--- a/jovian/utils/commit.py
+++ b/jovian/utils/commit.py
@@ -131,11 +131,14 @@ def commit(message=None,
             return
         if environment == "conda":
             log("Colab uses a pip environment, cannot capture conda environment. Capturing pip environment")
+            environment = "pip"
+        elif environment == "auto":
+            environment = "pip"
 
         res = perform_colab_commit(project, privacy)
         slug, username, version, title = res['slug'], res['owner']['username'], res['version'], res['title']
 
-        _capture_environment(environment="pip", slug, version)
+        _capture_environment(environment, slug, version)
         _attach_files(files, slug, version)
         _attach_files(outputs, slug, version, output=True)
         _attach_records(slug, version)

--- a/jovian/utils/commit.py
+++ b/jovian/utils/commit.py
@@ -130,7 +130,7 @@ def commit(message=None,
             log("Please provide the project argument e.g. jovian.commit(project='my-project')", error=True)
             return
         if environment == "conda":
-            log("Colab uses a pip environment, cannot capture conda environment. Capturing pip environment")
+            log("Colab uses a pip environment, cannot capture conda environment. Will Capture pip environment instead.")
             environment = "pip"
         elif environment == "auto":
             environment = "pip"

--- a/jovian/utils/commit.py
+++ b/jovian/utils/commit.py
@@ -130,13 +130,12 @@ def commit(message=None,
             log("Please provide the project argument e.g. jovian.commit(project='my-project')", error=True)
             return
         if environment == "conda":
-            log("Colab uses a pip environment, cannot capture conda environment. Capturing pip environment", error=True)
-
-        environment = "pip"
+            log("Colab uses a pip environment, cannot capture conda environment. Capturing pip environment")
 
         res = perform_colab_commit(project, privacy)
         slug, username, version, title = res['slug'], res['owner']['username'], res['version'], res['title']
-        _capture_environment(environment, slug, version)
+
+        _capture_environment(environment="pip", slug, version)
         _attach_files(files, slug, version)
         _attach_files(outputs, slug, version, output=True)
         _attach_records(slug, version)

--- a/jovian/utils/commit.py
+++ b/jovian/utils/commit.py
@@ -130,7 +130,7 @@ def commit(message=None,
             log("Please provide the project argument e.g. jovian.commit(project='my-project')", error=True)
             return
         if environment == "conda":
-            log("Colab uses a pip environment, cannot capture conda environment. Will Capture pip environment instead.")
+            log("Conda environment is not supported on Colab. Capturing pip environment instead.")
             environment = "pip"
         elif environment == "auto":
             environment = "pip"

--- a/jovian/utils/commit.py
+++ b/jovian/utils/commit.py
@@ -129,6 +129,11 @@ def commit(message=None,
         if project is None:
             log("Please provide the project argument e.g. jovian.commit(project='my-project')", error=True)
             return
+        if environment == "conda":
+            log("Colab uses a pip environment, cannot capture conda environment.")
+            return
+        elif environment == "auto":
+            environment = "pip"
 
         res = perform_colab_commit(project, privacy)
         slug, username, version, title = res['slug'], res['owner']['username'], res['version'], res['title']

--- a/jovian/utils/commit.py
+++ b/jovian/utils/commit.py
@@ -131,8 +131,11 @@ def commit(message=None,
             return
 
         res = perform_colab_commit(project, privacy)
-        username = res['owner']['username']
-        title = res['title']
+        slug, username, version, title = res['slug'], res['owner']['username'], res['version'], res['title']
+        _capture_environment(environment, slug, version)
+        _attach_files(files, slug, version)
+        _attach_files(outputs, slug, version, output=True)
+        _attach_records(slug, version)
 
         log('Committed successfully! ' + urljoin(read_webapp_url(), username, title))
         return urljoin(read_webapp_url(), username, title)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24864161/95151159-8e1b0380-07a7-11eb-8ef8-da8864a9e46a.png)
Reference Notebook: https://jovian.ml/PrajwalPrashanth/colab-improvements

- Colab has a pip env:
  - Added apt. error log to convey this when `environment="conda"`
  - Default `environment="auto"`, is replaced with `environment="pip"` as this will complain with a error log about not able to find conda env